### PR TITLE
feat: in keyword support

### DIFF
--- a/convert/src/__test__/integration-tests/in-keyword.integration.ts
+++ b/convert/src/__test__/integration-tests/in-keyword.integration.ts
@@ -1,0 +1,11 @@
+import { convertDeployExecute } from "../utility";
+jest.setTimeout(99999999);
+
+describe("when converting in-keyword", () => {
+    it("will execute IfStatementWithInKeyword as if it were node", async () => {
+        const resultFromSfn = await convertDeployExecute("in-keyword", "IfStatementWithInKeyword");
+        const { IfStatementWithInKeyword } = require("../resources/in-keyword");
+        const resultFromNode = await IfStatementWithInKeyword();
+        expect(resultFromSfn).toEqual(resultFromNode);
+    });
+});

--- a/convert/src/__test__/output/asl/in-keyword-IfStatementWithInKeyword.json
+++ b/convert/src/__test__/output/asl/in-keyword-IfStatementWithInKeyword.json
@@ -1,0 +1,55 @@
+{
+  "StartAt": "Initialize",
+  "States": {
+    "Initialize": {
+      "Type": "Pass",
+      "ResultPath": "$",
+      "Parameters": {
+        "vars.$": "$$.Execution.Input",
+        "_undefined": null
+      },
+      "Next": "Assign val"
+    },
+    "Assign val": {
+      "Type": "Pass",
+      "ResultPath": "$.vars.val",
+      "Result": {
+        "greeting": "hello"
+      },
+      "Comment": "source: val = { greeting: \"hello\" }",
+      "Next": "If (\"greeting\" in val && ..."
+    },
+    "If (\"greeting\" in val && ...": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "And": [
+            {
+              "Variable": "$.vars.val.greeting",
+              "IsPresent": true
+            },
+            {
+              "Not": {
+                "Variable": "$.vars.val.somethingElse",
+                "IsPresent": true
+              }
+            }
+          ],
+          "Next": "Return \"success\""
+        }
+      ],
+      "Comment": "source: if (\"greeting\" in val && !(\"somethingElse\" in  ...",
+      "Default": "Return \"failure\""
+    },
+    "Return \"success\"": {
+      "End": true,
+      "Type": "Pass",
+      "Result": "success"
+    },
+    "Return \"failure\"": {
+      "End": true,
+      "Type": "Pass",
+      "Result": "failure"
+    }
+  }
+}

--- a/convert/src/__test__/output/iasl/in-keyword-IfStatementWithInKeyword.json
+++ b/convert/src/__test__/output/iasl/in-keyword-IfStatementWithInKeyword.json
@@ -1,0 +1,93 @@
+{
+  "statements": [
+    {
+      "name": {
+        "identifier": "val",
+        "_syntaxKind": "identifier",
+        "type": "object"
+      },
+      "expression": {
+        "stateName": "Assign val",
+        "parameters": {
+          "properties": {
+            "greeting": {
+              "value": "hello",
+              "type": "string",
+              "_syntaxKind": "literal"
+            }
+          },
+          "_syntaxKind": "literal-object"
+        },
+        "source": "val = { greeting: \"hello\" }",
+        "_syntaxKind": "asl-pass-state"
+      },
+      "stateName": "Assign val",
+      "_syntaxKind": "variable-assignment"
+    },
+    {
+      "stateName": "If (\"greeting\" in val && ...",
+      "condition": {
+        "lhs": {
+          "lhs": {
+            "value": "greeting",
+            "type": "string",
+            "_syntaxKind": "literal"
+          },
+          "operator": "exists-in",
+          "rhs": {
+            "identifier": "val",
+            "_syntaxKind": "identifier",
+            "type": "object"
+          },
+          "_syntaxKind": "binary-expression"
+        },
+        "operator": "and",
+        "rhs": {
+          "operator": "not",
+          "rhs": {
+            "lhs": {
+              "value": "somethingElse",
+              "type": "string",
+              "_syntaxKind": "literal"
+            },
+            "operator": "exists-in",
+            "rhs": {
+              "identifier": "val",
+              "_syntaxKind": "identifier",
+              "type": "object"
+            },
+            "_syntaxKind": "binary-expression"
+          },
+          "_syntaxKind": "binary-expression"
+        },
+        "_syntaxKind": "binary-expression"
+      },
+      "then": {
+        "statements": [
+          {
+            "expression": {
+              "value": "success",
+              "type": "string",
+              "_syntaxKind": "literal"
+            },
+            "_syntaxKind": "return",
+            "stateName": "Return \"success\""
+          }
+        ],
+        "_syntaxKind": "function"
+      },
+      "source": "if (\"greeting\" in val && !(\"somethingElse\" in val)) {\n    return \"success\";\n  }",
+      "_syntaxKind": "if"
+    },
+    {
+      "expression": {
+        "value": "failure",
+        "type": "string",
+        "_syntaxKind": "literal"
+      },
+      "_syntaxKind": "return",
+      "stateName": "Return \"failure\""
+    }
+  ],
+  "_syntaxKind": "statemachine"
+}

--- a/convert/src/__test__/output/ts-lib/in-keyword-IfStatementWithInKeyword.ts
+++ b/convert/src/__test__/output/ts-lib/in-keyword-IfStatementWithInKeyword.ts
@@ -1,0 +1,20 @@
+
+import * as asl from "@ts2asl/asl-lib";
+
+export const IfStatementWithInKeyword = asl.deploy.asStateMachine(async () =>{
+    let val = asl.pass({
+        name: "Assign val",
+        parameters: () => ({ greeting: "hello" }),
+        comment: "val = { greeting: \"hello\" }"
+    });
+    asl.typescriptIf({
+        name: "If (\"greeting\" in val && ...",
+        condition: () => "greeting" in val && !("somethingElse" in val),
+        then: async () => {
+            return "success";
+        },
+        comment: "if (\"greeting\" in val && !(\"somethingElse\" in val)) {\n    return \"success\";\n  }"
+    })
+    return "failure";
+    ;
+});

--- a/convert/src/__test__/resources/in-keyword.ts
+++ b/convert/src/__test__/resources/in-keyword.ts
@@ -1,0 +1,10 @@
+
+import * as asl from "@ts2asl/asl-lib";
+
+export const IfStatementWithInKeyword = asl.deploy.asStateMachine(async () => {
+  let val = { greeting: "hello" };
+  if ("greeting" in val && !("somethingElse" in val)) {
+    return "success";
+  }
+  return "failure";;
+});

--- a/convert/src/__test__/tests/in-keyword.test.ts
+++ b/convert/src/__test__/tests/in-keyword.test.ts
@@ -1,0 +1,68 @@
+import { runConvertForTest } from "../utility";
+describe("when converting in-keyword", () => {
+  let converted;
+  beforeAll(() => {
+    converted = runConvertForTest("in-keyword");
+  });
+  it("then IfStatementWithInKeyword can be converted to asl", async () => {
+    expect(converted.IfStatementWithInKeyword.asl).toMatchInlineSnapshot(`
+      Object {
+        "StartAt": "Initialize",
+        "States": Object {
+          "Assign val": Object {
+            "Comment": "source: val = { greeting: \\"hello\\" }",
+            "Next": "If (\\"greeting\\" in val && ...",
+            "Result": Object {
+              "greeting": "hello",
+            },
+            "ResultPath": "$.vars.val",
+            "Type": "Pass",
+          },
+          "If (\\"greeting\\" in val && ...": Object {
+            "Choices": Array [
+              Object {
+                "And": Array [
+                  Object {
+                    "IsPresent": true,
+                    "Variable": "$.vars.val.greeting",
+                  },
+                  Object {
+                    "Not": Object {
+                      "IsPresent": true,
+                      "Variable": "$.vars.val.somethingElse",
+                    },
+                  },
+                ],
+                "Next": "Return \\"success\\"",
+              },
+            ],
+            "Comment": "source: if (\\"greeting\\" in val && !(\\"somethingElse\\" in  ...",
+            "Default": "Return \\"failure\\"",
+            "Type": "Choice",
+          },
+          "Initialize": Object {
+            "Next": "Assign val",
+            "Parameters": Object {
+              "_undefined": null,
+              "vars.$": "$$.Execution.Input",
+            },
+            "ResultPath": "$",
+            "Type": "Pass",
+          },
+          "Return \\"failure\\"": Object {
+            "Comment": undefined,
+            "End": true,
+            "Result": "failure",
+            "Type": "Pass",
+          },
+          "Return \\"success\\"": Object {
+            "Comment": undefined,
+            "End": true,
+            "Result": "success",
+            "Type": "Pass",
+          },
+        },
+      }
+    `);
+  });
+});

--- a/convert/src/convert-asllib-to-iasl/ast.ts
+++ b/convert/src/convert-asllib-to-iasl/ast.ts
@@ -129,31 +129,31 @@ export const visitNodes = (node: Expression, visitor: (node: Expression) => void
       visitNodes(arg, visitor);
     }
   } else if (Check.isAslTaskState(node)) {
-    visitNodes(node.parameters, visitor)
+    visitNodes(node.parameters, visitor);
   } else if (Check.isReturnStatement(node)) {
-    visitNodes(node.expression, visitor)
+    visitNodes(node.expression, visitor);
   }
   else if (Check.isTypeOfExpression(node)) {
-    visitNodes(node.operand, visitor)
+    visitNodes(node.operand, visitor);
   } else if (Check.isBinaryExpression(node)) {
-    if (node.lhs) visitNodes(node.lhs, visitor)
-    visitNodes(node.rhs, visitor)
+    if (node.lhs) visitNodes(node.lhs, visitor);
+    visitNodes(node.rhs, visitor);
   } else if (Check.isBlock(node)) {
     for (const child of node.statements) {
-      visitNodes(child, visitor)
+      visitNodes(child, visitor);
     }
   } else if (Check.isFunction(node)) {
-    if (node.inputArgumentName) visitNodes(node.inputArgumentName, visitor)
+    if (node.inputArgumentName) visitNodes(node.inputArgumentName, visitor);
     for (const child of node.statements) {
-      visitNodes(child, visitor)
+      visitNodes(child, visitor);
     }
   } else if (Check.isStateMachine(node)) {
     for (const child of node.statements) {
-      visitNodes(child, visitor)
+      visitNodes(child, visitor);
     }
   } else if (Check.isAslChoiceState(node)) {
     for (const choice of (node.choices || [])) {
-      visitNodes(choice.condition, visitor)
+      visitNodes(choice.condition, visitor);
       visitNodes(choice.block, visitor);
     }
     if (node.default) visitNodes(node.default, visitor);
@@ -165,7 +165,7 @@ export const visitNodes = (node: Expression, visitor: (node: Expression) => void
     visitNodes(node.iterator, visitor);
   } else if (Check.isAslParallelState(node)) {
     for (const child of node.branches) {
-      visitNodes(child, visitor)
+      visitNodes(child, visitor);
     }
   } else if (Check.isIfExpression(node)) {
     visitNodes(node.condition, visitor);
@@ -176,39 +176,39 @@ export const visitNodes = (node: Expression, visitor: (node: Expression) => void
       if (child.when) {
         visitNodes(child.when, visitor);
       }
-      visitNodes(child.then, visitor)
+      visitNodes(child.then, visitor);
     }
   } else if (Check.isDoWhileStatement(node)) {
     visitNodes(node.condition, visitor);
-    visitNodes(node.while, visitor)
+    visitNodes(node.while, visitor);
   } else if (Check.isTryExpression(node)) {
     visitNodes(node.try, visitor);
     for (const child of (node.catch || [])) {
-      visitNodes(child.block, visitor)
+      visitNodes(child.block, visitor);
     }
     if (node.finally) visitNodes(node.finally, visitor);
   } else if (Check.isWhileStatement(node)) {
     visitNodes(node.condition, visitor);
     visitNodes(node.while, visitor);
   } else if (Check.isAslPassState(node)) {
-    visitNodes(node.parameters, visitor)
+    visitNodes(node.parameters, visitor);
   } else if (Check.isLiteralObject(node)) {
     for (const prop of Object.values(node.properties)) {
-      visitNodes(prop, visitor)
+      visitNodes(prop, visitor);
     }
   } else if (Check.isAslWaitState(node)) {
-    visitNodes(node.seconds, visitor)
-    visitNodes(node.timestamp, visitor)
+    visitNodes(node.seconds, visitor);
+    visitNodes(node.timestamp, visitor);
   } else if (Check.isIdentifier(node)) {
     if (node.filterExpression) {
-      visitNodes(node.filterExpression.argument, visitor)
+      visitNodes(node.filterExpression.argument, visitor);
       visitNodes(node.filterExpression.expression, visitor);
     }
     if (node.indexExpression) {
-      visitNodes(node.indexExpression, visitor)
+      visitNodes(node.indexExpression, visitor);
     }
   }
-}
+};
 
 let scopeCounter = 1;
 export const assignScopes = (node: Expression, scope: Scope, visitor: (node: Expression, scope: Scope) => void) => {
@@ -221,40 +221,40 @@ export const assignScopes = (node: Expression, scope: Scope, visitor: (node: Exp
       assignScopes(arg, scope, visitor);
     }
   } else if (Check.isAslTaskState(node)) {
-    assignScopes(node.parameters, scope, visitor)
+    assignScopes(node.parameters, scope, visitor);
   } else if (Check.isReturnStatement(node)) {
-    assignScopes(node.expression, scope, visitor)
+    assignScopes(node.expression, scope, visitor);
   }
   else if (Check.isTypeOfExpression(node)) {
-    assignScopes(node.operand, scope, visitor)
+    assignScopes(node.operand, scope, visitor);
   } else if (Check.isBinaryExpression(node)) {
-    if (node.lhs) assignScopes(node.lhs, scope, visitor)
-    assignScopes(node.rhs, scope, visitor)
+    if (node.lhs) assignScopes(node.lhs, scope, visitor);
+    assignScopes(node.rhs, scope, visitor);
   } else if (Check.isBlock(node)) {
     const childScope = { accessed: [], enclosed: [], childScopes: [], parentScope: scope, id: "block-" + (scopeCounter += 1) } as Scope;
     scope.childScopes.push(childScope);
     for (const child of node.statements) {
-      assignScopes(child, scope, visitor)
+      assignScopes(child, scope, visitor);
     }
     node.scope = childScope.id;
   } else if (Check.isFunction(node)) {
-    if (node.inputArgumentName) assignScopes(node.inputArgumentName, scope, visitor)
+    if (node.inputArgumentName) assignScopes(node.inputArgumentName, scope, visitor);
     const childScope = { accessed: [], enclosed: [], childScopes: [], parentScope: scope, id: "function-" + (scopeCounter += 1) } as Scope;
     scope.childScopes.push(childScope);
     for (const child of node.statements) {
-      assignScopes(child, childScope, visitor)
+      assignScopes(child, childScope, visitor);
     }
     node.scope = childScope.id;
   } else if (Check.isStateMachine(node)) {
     const childScope = { accessed: [], enclosed: [], childScopes: [], parentScope: scope, id: "state-machine-" + (scopeCounter += 1) } as Scope;
     scope.childScopes.push(childScope);
     for (const child of node.statements) {
-      assignScopes(child, childScope, visitor)
+      assignScopes(child, childScope, visitor);
     }
     node.scope = childScope.id;
   } else if (Check.isAslChoiceState(node)) {
     for (const choice of (node.choices || [])) {
-      assignScopes(choice.condition, scope, visitor)
+      assignScopes(choice.condition, scope, visitor);
       assignScopes(choice.block, scope, visitor);
     }
     if (node.default) assignScopes(node.default, scope, visitor);
@@ -266,7 +266,7 @@ export const assignScopes = (node: Expression, scope: Scope, visitor: (node: Exp
     assignScopes(node.iterator, scope, visitor);
   } else if (Check.isAslParallelState(node)) {
     for (const child of node.branches) {
-      assignScopes(child, scope, visitor)
+      assignScopes(child, scope, visitor);
     }
   } else if (Check.isIfExpression(node)) {
     assignScopes(node.condition, scope, visitor);
@@ -277,39 +277,39 @@ export const assignScopes = (node: Expression, scope: Scope, visitor: (node: Exp
       if (child.when) {
         assignScopes(child.when, scope, visitor);
       }
-      assignScopes(child.then, scope, visitor)
+      assignScopes(child.then, scope, visitor);
     }
   } else if (Check.isDoWhileStatement(node)) {
     assignScopes(node.condition, scope, visitor);
-    assignScopes(node.while, scope, visitor)
+    assignScopes(node.while, scope, visitor);
   } else if (Check.isTryExpression(node)) {
     assignScopes(node.try, scope, visitor);
     for (const child of (node.catch || [])) {
-      assignScopes(child.block, scope, visitor)
+      assignScopes(child.block, scope, visitor);
     }
     if (node.finally) assignScopes(node.finally, scope, visitor);
   } else if (Check.isWhileStatement(node)) {
     assignScopes(node.condition, scope, visitor);
     assignScopes(node.while, scope, visitor);
   } else if (Check.isAslPassState(node)) {
-    assignScopes(node.parameters, scope, visitor)
+    assignScopes(node.parameters, scope, visitor);
   } else if (Check.isLiteralObject(node)) {
     for (const prop of Object.values(node.properties)) {
-      assignScopes(prop, scope, visitor)
+      assignScopes(prop, scope, visitor);
     }
   } else if (Check.isAslWaitState(node)) {
-    assignScopes(node.seconds, scope, visitor)
-    assignScopes(node.timestamp, scope, visitor)
+    assignScopes(node.seconds, scope, visitor);
+    assignScopes(node.timestamp, scope, visitor);
   } else if (Check.isIdentifier(node)) {
     if (node.filterExpression) {
-      assignScopes(node.filterExpression.argument, scope, visitor)
+      assignScopes(node.filterExpression.argument, scope, visitor);
       assignScopes(node.filterExpression.expression, scope, visitor);
     }
     if (node.indexExpression) {
-      assignScopes(node.indexExpression, scope, visitor)
+      assignScopes(node.indexExpression, scope, visitor);
     }
   }
-}
+};
 
 export interface StateMachine extends Function {
   contextArgumentName?: Identifier;
@@ -326,10 +326,10 @@ export interface Identifier {
   objectContextExpression?: true; //is this an expression against the statemachine global context?
   identifier: string;
   indexExpression?: Identifier | Expression;
-  sliceExpression?: { start: number, end?: number, step?: number };
+  sliceExpression?: { start: number, end?: number, step?: number; };
   filterExpression?: {
     argument: Identifier,
-    expression: BinaryExpression
+    expression: BinaryExpression;
   },
   mapExpression?: string;
   jsonPathExpression?: string;
@@ -364,7 +364,7 @@ export interface Scope {
   parentScope: Scope | undefined;
 }
 
-export type BinaryOperator = "and" | "or" | "not" | "is-truthy" | "matches" | "eq" | "gt" | "gte" | "lt" | "lte";
+export type BinaryOperator = "exists-in" | "and" | "or" | "not" | "is-truthy" | "matches" | "eq" | "gt" | "gte" | "lt" | "lte";
 
 
 export interface BinaryExpression extends Expression {
@@ -433,7 +433,7 @@ export interface ForEachStatement extends Expression {
 
 export interface SwitchStatement extends Expression {
   _syntaxKind: SyntaxKind.Switch;
-  cases?: Array<{ when?: BinaryExpression, then: Block }>;
+  cases?: Array<{ when?: BinaryExpression, then: Block; }>;
 }
 export interface DoWhileStatement extends Expression {
   _syntaxKind: SyntaxKind.DoWhileStatement;
@@ -460,7 +460,7 @@ export interface ReturnStatement extends Expression {
 
 export interface Block extends Expression, DeclaresScope {
   _syntaxKind: SyntaxKind.Block | SyntaxKind.Function | SyntaxKind.StateMachine;
-  statements: Expression[]
+  statements: Expression[];
 }
 
 ///ASL States
@@ -473,9 +473,9 @@ export declare type RetryConfiguration = Array<{
   intervalSeconds?: number;
   maxAttempts?: number;
   backoffRate?: number;
-}>
+}>;
 
-export type CatchConfiguration = Array<{ errorEquals: string[], block: Function }>;
+export type CatchConfiguration = Array<{ errorEquals: string[], block: Function; }>;
 
 export interface WaitState extends AslState {
   _syntaxKind: SyntaxKind.AslWaitState;
@@ -484,7 +484,7 @@ export interface WaitState extends AslState {
 }
 
 export interface ParallelState extends AslState {
-  _syntaxKind: SyntaxKind.AslParallelState
+  _syntaxKind: SyntaxKind.AslParallelState;
   branches: (Function)[];
   catch?: CatchConfiguration;
   retry?: RetryConfiguration;
@@ -510,8 +510,8 @@ export interface TaskState extends AslState {
 }
 
 export interface ChoiceState extends AslState {
-  _syntaxKind: SyntaxKind.AslChoiceState
-  choices?: Array<{ condition: BinaryExpression, block: Block }>;
+  _syntaxKind: SyntaxKind.AslChoiceState;
+  choices?: Array<{ condition: BinaryExpression, block: Block; }>;
   default?: Block;
 }
 
@@ -526,7 +526,7 @@ export interface MapState extends AslState {
 }
 
 export interface FailState extends AslState {
-  _syntaxKind: SyntaxKind.AslFailState
+  _syntaxKind: SyntaxKind.AslFailState;
   cause?: string;
   error?: string;
 }

--- a/convert/src/convert-asllib-to-iasl/index.ts
+++ b/convert/src/convert-asllib-to-iasl/index.ts
@@ -1,6 +1,6 @@
 
 import * as ts from "typescript";
-import * as iasl from "./ast"
+import * as iasl from "./ast";
 import { ParserError } from "../ParserError";
 import { convertToIdentifier } from "./helper";
 import { removeSyntaxTransformer } from "./remove-syntax-transformer";
@@ -45,8 +45,8 @@ export const convertToIntermediaryAsl = (body: ts.Block | ts.ConciseBody | ts.So
     contextArgumentName: context.contextArgumentName ? { identifier: context.contextArgumentName, _syntaxKind: iasl.SyntaxKind.Identifier } as iasl.Identifier : undefined,
     statements: result,
     _syntaxKind: iasl.SyntaxKind.StateMachine
-  }
-}
+  };
+};
 export const convertNodeToIntermediaryAst = (toplevel: ts.Node, context: ConverterContext): iasl.Expression[] | iasl.Expression | undefined => {
   let node: ts.Node | undefined = toplevel;
 
@@ -88,7 +88,7 @@ export const convertNodeToIntermediaryAst = (toplevel: ts.Node, context: Convert
           stateName: `Return result`,
           _syntaxKind: iasl.SyntaxKind.ReturnStatement,
         } as iasl.ReturnStatement,
-      ]
+      ];
     }
     else {
       const identifier = node.expression ? convertExpressionToLiteralOrIdentifier(node.expression, {}, context) : undefined;
@@ -118,7 +118,7 @@ export const convertNodeToIntermediaryAst = (toplevel: ts.Node, context: Convert
       expression: expression,
       stateName: createName(context.converterOptions, node, `Assign %s`, decl.name),
       _syntaxKind: iasl.SyntaxKind.VariableAssignmentStatement
-    } as iasl.VariableAssignmentStatement
+    } as iasl.VariableAssignmentStatement;
   }
 
   if ((ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken)) {
@@ -135,7 +135,7 @@ export const convertNodeToIntermediaryAst = (toplevel: ts.Node, context: Convert
       expression: expression,
       stateName: createName(context.converterOptions, node, `Assign %s`, node.left),
       _syntaxKind: iasl.SyntaxKind.VariableAssignmentStatement
-    } as iasl.VariableAssignmentStatement
+    } as iasl.VariableAssignmentStatement;
   }
 
   if (node && ts.isAwaitExpression(node)) {
@@ -147,7 +147,7 @@ export const convertNodeToIntermediaryAst = (toplevel: ts.Node, context: Convert
       stateName: createName(context.converterOptions, node, "Return %s", node.expression!),
       expression: convertExpression(node.expression, context),
       _syntaxKind: iasl.SyntaxKind.ReturnStatement
-    } as iasl.ReturnStatement
+    } as iasl.ReturnStatement;
   }
 
   if (ts.isBreakStatement(node)) {
@@ -169,7 +169,7 @@ export const convertNodeToIntermediaryAst = (toplevel: ts.Node, context: Convert
     throw new ParserError("unknown expression type", node);
   }
   return result;
-}
+};
 
 export const convertSingleExpression = (expression: ts.Expression | undefined, context: ConverterContext): iasl.Expression | undefined => {
   const result = convertExpression(expression, context);
@@ -179,7 +179,7 @@ export const convertSingleExpression = (expression: ts.Expression | undefined, c
     throw new Error("expected single expression");
   }
   return result[0];
-}
+};
 
 export const convertExpression = (expression: ts.Expression | undefined, context: ConverterContext): iasl.Expression[] | iasl.Expression | undefined => {
   if (!expression) return undefined;
@@ -480,7 +480,7 @@ export const convertExpression = (expression: ts.Expression | undefined, context
         const name = unpackAsLiteral(convertedArgs, "name");
         const expression = unpackAsIdentifier(convertedArgs, "expression");
         const cases = unpackArray(convertedArgs, "cases", element => {
-          const unpackedSimple = unpackLiteralValue(element) as { label: string | number | undefined, block: iasl.Block };
+          const unpackedSimple = unpackLiteralValue(element) as { label: string | number | undefined, block: iasl.Block; };
           if (unpackedSimple.label !== undefined) {
             return {
               when: {
@@ -490,11 +490,11 @@ export const convertExpression = (expression: ts.Expression | undefined, context
                 _syntaxKind: iasl.SyntaxKind.BinaryExpression,
               } as iasl.BinaryExpression,
               then: unpackedSimple.block,
-            }
+            };
           } else {
             return {
               then: unpackedSimple.block,
-            }
+            };
           }
         });
         const comment = unpackAsLiteral(convertedArgs, "comment");
@@ -579,7 +579,7 @@ export const convertExpression = (expression: ts.Expression | undefined, context
           properties: {},
           _syntaxKind: iasl.SyntaxKind.LiteralObject
         } as iasl.LiteralObjectExpression
-      }
+      };
 
 
       const parameters = convertedArgs.parameters as iasl.LiteralObjectExpression;
@@ -605,7 +605,7 @@ export const convertExpression = (expression: ts.Expression | undefined, context
       throw new ParserError(`unknown asl lib function: asl.${type}`, expression);
     }
   }
-}
+};
 
 
 export const convertObjectLiteralExpression = (expr: ts.ObjectLiteralExpression, context: ConverterContext): Record<string, iasl.Expression | iasl.Identifier> => {
@@ -621,12 +621,12 @@ export const convertObjectLiteralExpression = (expr: ts.ObjectLiteralExpression,
 
     const initializer = convertExpressionToLiteralOrIdentifier(property.initializer, { block: ["block", "default", "iterator"].includes(propertyName) }, context);
     if (initializer === undefined) continue;
-    result[propertyName] = initializer
+    result[propertyName] = initializer;
   }
-  return result
-}
+  return result;
+};
 
-export const convertExpressionToLiteralOrIdentifier = (original: ts.Expression | undefined, hints: { block?: boolean }, context: ConverterContext): iasl.Identifier | iasl.LiteralExpressionLike | iasl.AslIntrinsicFunction | iasl.TypeOfExpression | iasl.BinaryExpression | iasl.Expression | undefined => {
+export const convertExpressionToLiteralOrIdentifier = (original: ts.Expression | undefined, hints: { block?: boolean; }, context: ConverterContext): iasl.Identifier | iasl.LiteralExpressionLike | iasl.AslIntrinsicFunction | iasl.TypeOfExpression | iasl.BinaryExpression | iasl.Expression | undefined => {
   if (original === undefined) {
     return undefined;
   }
@@ -715,7 +715,7 @@ export const convertExpressionToLiteralOrIdentifier = (original: ts.Expression |
       const functionName = convertToIdentifier(expr.expression, context);
 
       if (!(functionName?.identifier) || functionName.indexExpression || functionName.lhs) {
-        throw new Error("call expression must be simple identifier")
+        throw new Error("call expression must be simple identifier");
       }
       return {
         arguments: _arguments,
@@ -796,7 +796,7 @@ export const convertExpressionToLiteralOrIdentifier = (original: ts.Expression |
             if (!ts.isNumericLiteral(startArg)) throw new Error("asl.jsonPathExpression 2nd arg must be number literal");
             const sliceExpression = {
               start: Number(startArg.text),
-            } as { start: number, end: number | undefined, step: number | undefined };
+            } as { start: number, end: number | undefined, step: number | undefined; };
 
             if (expr.arguments.length > 2) {
               const endArg = expr.arguments[2];
@@ -823,7 +823,7 @@ export const convertExpressionToLiteralOrIdentifier = (original: ts.Expression |
     } as iasl.TypeOfExpression;
     return expression;
   } else if (ts.isBinaryExpression(expr)) {
-    const convertedOperator = convertBinaryOperatorToken(expr.operatorToken)
+    const convertedOperator = convertBinaryOperatorToken(expr.operatorToken);
     let expression = {
       lhs: convertExpressionToLiteralOrIdentifier(expr.left, {}, context),
       operator: convertedOperator.op,
@@ -861,7 +861,7 @@ export const convertExpressionToLiteralOrIdentifier = (original: ts.Expression |
     } as iasl.BreakStatement;
   }
 
-  const converted = convertExpression(expr, context)
+  const converted = convertExpression(expr, context);
   if (converted) {
     if (Array.isArray(converted)) {
       return {
@@ -877,7 +877,7 @@ export const convertExpressionToLiteralOrIdentifier = (original: ts.Expression |
     return identifier;
   }
   throw new ParserError("unable to unpack expression ", expr);
-}
+};
 
 const unpackAsLiteral = (args: Record<string, iasl.Expression | iasl.Identifier>, propertyName: string): string | boolean | number | null | undefined => {
   const propValue = args[propertyName];
@@ -887,7 +887,7 @@ const unpackAsLiteral = (args: Record<string, iasl.Expression | iasl.Identifier>
     throw new Error(`property ${propertyName} must be literal`);
   }
   return propValue.value;
-}
+};
 
 const unpackAsBinaryExpression = (args: Record<string, iasl.Expression | iasl.Identifier>, propertyName: string): iasl.BinaryExpression | iasl.LiteralExpression | undefined => {
   const propValue = args[propertyName];
@@ -911,7 +911,7 @@ const unpackAsBinaryExpression = (args: Record<string, iasl.Expression | iasl.Id
     throw new Error(`property ${propertyName} must be binary expression`);
   }
   return propValue;
-}
+};
 
 const unpackLiteralValue = (val: iasl.Expression | iasl.Identifier) => {
   if (iasl.Check.isLiteral(val)) {
@@ -929,7 +929,7 @@ const unpackLiteralValue = (val: iasl.Expression | iasl.Identifier) => {
   }
 
   return val;
-}
+};
 
 const unpackArray = <TElement>(args: Record<string, iasl.Expression | iasl.Identifier>, propertyName: string, unpackElement: (element: iasl.Expression | iasl.Identifier) => TElement): TElement[] | undefined => {
   const propValue = args[propertyName];
@@ -940,7 +940,7 @@ const unpackArray = <TElement>(args: Record<string, iasl.Expression | iasl.Ident
   }
 
   return propValue.elements.map(x => unpackElement(x));
-}
+};
 
 const unpackBlock = (args: Record<string, iasl.Expression | iasl.Identifier>, propertyName: string): iasl.Block | undefined => {
   let propValue = args[propertyName];
@@ -987,7 +987,7 @@ const unpackBlock = (args: Record<string, iasl.Expression | iasl.Identifier>, pr
     }
   }
   return propValue as unknown as iasl.Block;
-}
+};
 
 
 const unpackAsIdentifier = (args: Record<string, iasl.Expression | iasl.Identifier>, propertyName: string): iasl.Identifier | undefined => {
@@ -998,10 +998,10 @@ const unpackAsIdentifier = (args: Record<string, iasl.Expression | iasl.Identifi
     throw new Error(`property ${propertyName} must be identifier`);
   }
   return propValue;
-}
+};
 
 
-const convertBinaryOperatorToken = (operator: ts.BinaryOperatorToken): { op: iasl.BinaryOperator, not: boolean } => {
+const convertBinaryOperatorToken = (operator: ts.BinaryOperatorToken): { op: iasl.BinaryOperator, not: boolean; } => {
   switch (operator.kind) {
     case ts.SyntaxKind.EqualsEqualsEqualsToken:
     case ts.SyntaxKind.EqualsEqualsToken:
@@ -1029,8 +1029,11 @@ const convertBinaryOperatorToken = (operator: ts.BinaryOperatorToken): { op: ias
     case ts.SyntaxKind.AmpersandAmpersandToken:
       return { op: "and", not: false };
 
+    case ts.SyntaxKind.InKeyword:
+      return { op: "exists-in", not: false };
+
     default:
       const typescriptOp = ts.SyntaxKind[operator.kind];
       throw new Error("unexpected binary operator type " + typescriptOp);
   }
-}
+};

--- a/examples/in-keyword.md
+++ b/examples/in-keyword.md
@@ -1,0 +1,16 @@
+
+## if statement with in keyword
+[Open in playground](https://asl-editor-spike-ts-stedi.vercel.app/?aW1wb3J0ICogYXMgYXNsIGZyb20gIkB0czJhc2wvYXNsLWxpYiIKCmV4cG9ydCBjb25zdCBtYWluID0gYXNsLmRlcGxveS5hc1N0YXRlTWFjaGluZShhc3luYyAoKSA9PiAKIHsKICBsZXQgdmFsID0geyBncmVldGluZzogImhlbGxvIiB9OwogIGlmICgiZ3JlZXRpbmciIGluIHZhbCAmJiAhKCJzb21ldGhpbmdFbHNlIiBpbiB2YWwpKSB7CiAgICByZXR1cm4gInN1Y2Nlc3MiOwogIH0KICByZXR1cm4gImZhaWx1cmUiOzsKfSk7)
+
+``` typescript
+export const main = asl.deploy.asStateMachine(async () => 
+ {
+  let val = { greeting: "hello" };
+  if ("greeting" in val && !("somethingElse" in val)) {
+    return "success";
+  }
+  return "failure";;
+});
+```
+
+

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,7 @@ interface IInput {
 * [input validation](./examples/input-validation.md)
 * [enclosed variables](./examples/closures.md)
 * [enum literals](./examples/enums.md)
+* [in keyword](./examples/in-keyword.md)
 * [if statements](./examples/if.md)
 * [for ... of statements](./examples/for-each.md)
 * [do while statements](./examples/do-while.md)


### PR DESCRIPTION
adds in keyword support to ts2asl.

example:
``` typescript
  let val = { greeting: "hello" };
  if ("greeting" in val && !("somethingElse" in val)) {
    return "success";
  }
  return "failure";
```
