### PR TITLE
fix: coerce literal types to either string/number/boolean

### DIFF
--- a/packages/convert/src/__test__/output/asl/kyc-main.json
+++ b/packages/convert/src/__test__/output/asl/kyc-main.json
@@ -87,36 +87,8 @@
       "Choices": [
         {
           "Not": {
-            "Or": [
-              {
-                "Variable": "$.vars.checksPassed",
-                "IsPresent": false
-              },
-              {
-                "Variable": "$.vars.checksPassed",
-                "IsNull": true
-              },
-              {
-                "Variable": "$.vars.checksPassed",
-                "BooleanEquals": false
-              },
-              {
-                "Variable": "$.vars.checksPassed",
-                "StringEquals": ""
-              },
-              {
-                "Variable": "$.vars.checksPassed",
-                "StringEquals": "false"
-              },
-              {
-                "Variable": "$.vars.checksPassed",
-                "StringEquals": "0"
-              },
-              {
-                "Variable": "$.vars.checksPassed",
-                "NumericEquals": 0
-              }
-            ]
+            "Variable": "$.vars.checksPassed",
+            "BooleanEquals": false
           },
           "Next": "PutEvents_1"
         }

--- a/packages/convert/src/__test__/output/iasl/boolean-evalation-numericComparison.json
+++ b/packages/convert/src/__test__/output/iasl/boolean-evalation-numericComparison.json
@@ -4,7 +4,7 @@
       "name": {
         "identifier": "condition",
         "_syntaxKind": "identifier",
-        "type": "unknown"
+        "type": "numeric"
       },
       "expression": {
         "stateName": "Assign condition",
@@ -84,7 +84,7 @@
                 "rhs": {
                   "identifier": "condition",
                   "_syntaxKind": "identifier",
-                  "type": "unknown"
+                  "type": "numeric"
                 },
                 "_syntaxKind": "binary-expression"
               },
@@ -96,7 +96,7 @@
                         "returned": {
                           "identifier": "item",
                           "_syntaxKind": "identifier",
-                          "type": "unknown"
+                          "type": "numeric"
                         }
                       },
                       "_syntaxKind": "literal-object"

--- a/packages/convert/src/__test__/output/iasl/closures-main.json
+++ b/packages/convert/src/__test__/output/iasl/closures-main.json
@@ -82,7 +82,7 @@
       "name": {
         "identifier": "global",
         "_syntaxKind": "identifier",
-        "type": "unknown"
+        "type": "string"
       },
       "expression": {
         "stateName": "Assign global",

--- a/packages/convert/src/__test__/output/iasl/do-while-doWhileWithEarlyReturn.json
+++ b/packages/convert/src/__test__/output/iasl/do-while-doWhileWithEarlyReturn.json
@@ -88,7 +88,7 @@
                   "expression": {
                     "identifier": "counter",
                     "_syntaxKind": "identifier",
-                    "type": "unknown"
+                    "type": "string"
                   },
                   "_syntaxKind": "return",
                   "stateName": "Return counter"

--- a/packages/convert/src/__test__/output/iasl/do-while-simpleDoWhile.json
+++ b/packages/convert/src/__test__/output/iasl/do-while-simpleDoWhile.json
@@ -76,7 +76,7 @@
       "expression": {
         "identifier": "counter",
         "_syntaxKind": "identifier",
-        "type": "unknown"
+        "type": "string"
       },
       "_syntaxKind": "return",
       "stateName": "Return counter"

--- a/packages/convert/src/__test__/output/iasl/enums-compareEnum.json
+++ b/packages/convert/src/__test__/output/iasl/enums-compareEnum.json
@@ -4,7 +4,7 @@
       "name": {
         "identifier": "x",
         "_syntaxKind": "identifier",
-        "type": "unknown"
+        "type": "numeric"
       },
       "expression": {
         "stateName": "Assign x",
@@ -25,7 +25,7 @@
         "lhs": {
           "identifier": "x",
           "_syntaxKind": "identifier",
-          "type": "unknown"
+          "type": "numeric"
         },
         "operator": "eq",
         "rhs": {

--- a/packages/convert/src/__test__/output/iasl/enums-compareStringEnum.json
+++ b/packages/convert/src/__test__/output/iasl/enums-compareStringEnum.json
@@ -4,7 +4,7 @@
       "name": {
         "identifier": "x",
         "_syntaxKind": "identifier",
-        "type": "unknown"
+        "type": "string"
       },
       "expression": {
         "stateName": "Assign x",
@@ -25,7 +25,7 @@
         "lhs": {
           "identifier": "x",
           "_syntaxKind": "identifier",
-          "type": "unknown"
+          "type": "string"
         },
         "operator": "eq",
         "rhs": {

--- a/packages/convert/src/__test__/output/iasl/for-each-foreachEarlyReturn.json
+++ b/packages/convert/src/__test__/output/iasl/for-each-foreachEarlyReturn.json
@@ -83,7 +83,7 @@
                       {
                         "identifier": "item",
                         "_syntaxKind": "identifier",
-                        "type": "unknown"
+                        "type": "numeric"
                       }
                     ],
                     "function": "asl.states.format",

--- a/packages/convert/src/__test__/output/iasl/for-each-nestedForeach.json
+++ b/packages/convert/src/__test__/output/iasl/for-each-nestedForeach.json
@@ -82,7 +82,7 @@
       "name": {
         "identifier": "global",
         "_syntaxKind": "identifier",
-        "type": "unknown"
+        "type": "string"
       },
       "expression": {
         "stateName": "Assign global",

--- a/packages/convert/src/__test__/output/iasl/kyc-main.json
+++ b/packages/convert/src/__test__/output/iasl/kyc-main.json
@@ -125,7 +125,7 @@
       "name": {
         "identifier": "checksPassed",
         "_syntaxKind": "identifier",
-        "type": "unknown"
+        "type": "boolean"
       },
       "expression": {
         "stateName": "Assign checksPassed",
@@ -147,7 +147,7 @@
         "rhs": {
           "identifier": "checksPassed",
           "_syntaxKind": "identifier",
-          "type": "unknown"
+          "type": "boolean"
         },
         "_syntaxKind": "binary-expression"
       },

--- a/packages/convert/src/__test__/output/iasl/sdk-states-cloudWatchPutMetricData.json
+++ b/packages/convert/src/__test__/output/iasl/sdk-states-cloudWatchPutMetricData.json
@@ -4,7 +4,7 @@
       "name": {
         "identifier": "value",
         "_syntaxKind": "identifier",
-        "type": "unknown"
+        "type": "numeric"
       },
       "expression": {
         "stateName": "Assign value",
@@ -36,7 +36,7 @@
                   "Value": {
                     "identifier": "value",
                     "_syntaxKind": "identifier",
-                    "type": "unknown"
+                    "type": "numeric"
                   }
                 },
                 "_syntaxKind": "literal-object"

--- a/packages/convert/src/__test__/output/iasl/ts-lib-convert-convertStringToBoolean.json
+++ b/packages/convert/src/__test__/output/iasl/ts-lib-convert-convertStringToBoolean.json
@@ -54,7 +54,7 @@
                 {
                   "identifier": "bool",
                   "_syntaxKind": "identifier",
-                  "type": "unknown"
+                  "type": "boolean"
                 }
               ],
               "function": "asl.states.format",

--- a/packages/convert/src/__test__/output/iasl/ts-lib-convert-convertStringToNumber.json
+++ b/packages/convert/src/__test__/output/iasl/ts-lib-convert-convertStringToNumber.json
@@ -54,7 +54,7 @@
                 {
                   "identifier": "num",
                   "_syntaxKind": "identifier",
-                  "type": "unknown"
+                  "type": "numeric"
                 }
               ],
               "function": "asl.states.format",

--- a/packages/convert/src/__test__/output/iasl/while-simpleWhile.json
+++ b/packages/convert/src/__test__/output/iasl/while-simpleWhile.json
@@ -76,7 +76,7 @@
       "expression": {
         "identifier": "counter",
         "_syntaxKind": "identifier",
-        "type": "unknown"
+        "type": "string"
       },
       "_syntaxKind": "return",
       "stateName": "Return counter"

--- a/packages/convert/src/__test__/output/iasl/while-whileWithEarlyReturn.json
+++ b/packages/convert/src/__test__/output/iasl/while-whileWithEarlyReturn.json
@@ -88,7 +88,7 @@
                   "expression": {
                     "identifier": "counter",
                     "_syntaxKind": "identifier",
-                    "type": "unknown"
+                    "type": "string"
                   },
                   "_syntaxKind": "return",
                   "stateName": "Return counter"

--- a/packages/convert/src/__test__/tests/kyc.test.ts
+++ b/packages/convert/src/__test__/tests/kyc.test.ts
@@ -74,36 +74,8 @@ describe("when converting kyc", () => {
               Object {
                 "Next": "PutEvents_1",
                 "Not": Object {
-                  "Or": Array [
-                    Object {
-                      "IsPresent": false,
-                      "Variable": "$.vars.checksPassed",
-                    },
-                    Object {
-                      "IsNull": true,
-                      "Variable": "$.vars.checksPassed",
-                    },
-                    Object {
-                      "BooleanEquals": false,
-                      "Variable": "$.vars.checksPassed",
-                    },
-                    Object {
-                      "StringEquals": "",
-                      "Variable": "$.vars.checksPassed",
-                    },
-                    Object {
-                      "StringEquals": "false",
-                      "Variable": "$.vars.checksPassed",
-                    },
-                    Object {
-                      "StringEquals": "0",
-                      "Variable": "$.vars.checksPassed",
-                    },
-                    Object {
-                      "NumericEquals": 0,
-                      "Variable": "$.vars.checksPassed",
-                    },
-                  ],
+                  "BooleanEquals": false,
+                  "Variable": "$.vars.checksPassed",
                 },
               },
             ],

--- a/packages/convert/src/convert-asllib-to-iasl/helper.ts
+++ b/packages/convert/src/convert-asllib-to-iasl/helper.ts
@@ -85,15 +85,15 @@ function convertType(type: ts.Type, symbol?: ts.Symbol): iasl.Type {
     return "object";
   }
 
-  if (hasFlag(type, ts.TypeFlags.String)) {
+  if (hasFlag(type, ts.TypeFlags.String) || hasFlag(type, ts.TypeFlags.StringLiteral)) {
     return "string";
   }
 
-  if (hasFlag(type, ts.TypeFlags.Number)) {
+  if (hasFlag(type, ts.TypeFlags.Number) || hasFlag(type, ts.TypeFlags.NumberLiteral)) {
     return "numeric";
   }
 
-  if (hasFlag(type, ts.TypeFlags.Boolean)) {
+  if (hasFlag(type, ts.TypeFlags.Boolean) || hasFlag(type, ts.TypeFlags.BooleanLiteral)) {
     return "boolean";
   }
   return "unknown";


### PR DESCRIPTION
coerce string literal types to strings, numeric literal types to numbers, and boolean literal types to boolean for boolean evaluation logic.

closes #33
