### PR TITLE
chore: let mergify use squash merges

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -27,4 +27,4 @@ pull_request_rules:
         # Branch protection rules still apply as configured in GitHub
     actions:
       merge:
-        method: merge
+        method: squash


### PR DESCRIPTION
Some PRs like https://github.com/Stedi/ts2asl/pull/645 are stuck because Mergify attempts to use "merge" over "squash". I recommend we switch to squash since I don't think multiple bot commits will help us in `main`.